### PR TITLE
update usdc logo on op chain

### DIFF
--- a/lists/token-lists/default-token-list/tokens/optimism.json
+++ b/lists/token-lists/default-token-list/tokens/optimism.json
@@ -443,7 +443,7 @@
     "address": "0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
     "chainId": 10,
     "decimals": 6,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/icons/master/token/usdc.jpg",
+    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/token/usdc.jpg",
     "name": "USD Coin",
     "symbol": "USDC"
   },


### PR DESCRIPTION
hi seem link https://raw.githubusercontent.com/sushiswap/icons/master/token/usdc.jpg retrun 404
<img width="770" alt="image" src="https://user-images.githubusercontent.com/11234402/225677487-f1932ee5-4985-4e5d-b018-21969f386025.png">

i update new link use `list` repo 
https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/token/usdc.jpg
<img width="913" alt="image" src="https://user-images.githubusercontent.com/11234402/225677727-82c79e3e-d0cb-4156-8af4-6ba1c691b13c.png">

