### PR TITLE
feat(default-token-list): remove malicious MKR token

### DIFF
--- a/.changeset/slow-camels-smile.md
+++ b/.changeset/slow-camels-smile.md
@@ -1,0 +1,5 @@
+---
+'@sushiswap/default-token-list': minor
+---
+
+Removes MKR malicious token from arbitrum default list

--- a/lists/token-lists/default-token-list/tokens/arbitrum.json
+++ b/lists/token-lists/default-token-list/tokens/arbitrum.json
@@ -480,14 +480,6 @@
     "symbol": "MIM"
   },
   {
-    "address": "0x2e9a6Df78E42a30712c10a9Dc4b1C8656f8F2879",
-    "chainId": 42161,
-    "decimals": 18,
-    "logoURI": "https://raw.githubusercontent.com/sushiswap/list/master/logos/token-logos/token/mkr.jpg",
-    "name": "Maker",
-    "symbol": "MKR"
-  },
-  {
     "address": "0x1FAe2A29940015632f2a6CE006dFA7E3225515A7",
     "chainId": 42161,
     "decimals": 9,


### PR DESCRIPTION
The contract at https://arbiscan.io/address/0x2e9a6df78e42a30712c10a9dc4b1c8656f8f2879#readProxyContract

Is not actually the MKR token contract. There is no official MKR token on arbitrum (https://docs.makerdao.com/deployment-addresses/multi-collateral-dai-public-releases)

This should be removed ASAP since it seems to be a malicious token, the l1 address seems to be correct but everything else is not
<img width="1413" alt="Screenshot 2023-04-20 at 14 09 22" src="https://user-images.githubusercontent.com/94012134/233438923-a132ee33-61e8-4fa4-ad80-9a3354e2822b.png">
